### PR TITLE
FIX: Assets 404

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,8 @@ module.exports = {
   ],
   output: {
     filename: 'bundle.js',
-    path: path.resolve(__dirname, 'public')
+    path: path.resolve(__dirname, 'public'),
+    publicPath: '/'
   },
   module: {
     rules: [


### PR DESCRIPTION
Adding publicPath as '/' to webpack output, to avoid the error 404 of relative paths for assets