### PR TITLE
Update Package.json Node Version to 14.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "react-hello",
 	"version": "1.0.1",
 	"engines": {
-		"node": "10.x"
+		"node": "14.x"
 	},
 	"description": "",
 	"main": "index.js",


### PR DESCRIPTION
Vercel deployments need a node version greater than or equal to 14.x

Message given by vercel CLI:

"Node.js Version "10.x" is discontinued and must be upgraded. Please set "engines": { "node": "14.x" } in your `package.json` file to use Node.js 14. This change is the result of a decision made by an upstream infrastructure provider (AWS)."